### PR TITLE
feat(crossplatform): add cross platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Requirements
             * Xenial (16.04)
             * Bionic (18.04)
 
+        * Raspbian
+            
+            * 10
+        
     * RedHat Family
 
         * CentOS
@@ -45,6 +49,13 @@ Requirements
             * 15.1
 
     * Note: other versions are likely to work but have not been tested.
+
+* MacOS
+    * High Sierra (10.13)  
+    * Mojave (10.14)
+    * Catalina (10.15)
+    * Big Sur (11.0)
+
 
 * Docker (already installed)
 
@@ -64,6 +75,15 @@ ctop_redis_sha256sum: '43d41ed0b2bb5cfc2aaa7b7fdd2d6cb515f6d88adc40ff40e3ec1f560
 # Directory to store files downloaded for ctop
 ctop_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 ```
+
+The role should automatically determine your operating system and architecture.
+If it does not, then these can be set with:
+
+* `ctop_os`: tested with `linux` and `darwin`
+* `ctop_architecture`: tested with `amd64`, `arm`, and `arm64`.
+
+Note that combinations of these values only work to the extent that there are
+pre-built binaries of ctop available.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,24 @@
 # ctop version number
 ctop_version: '0.7.4'
 
-# SHA256 sum for the ctop redistributable
-ctop_redis_sha256sum: '43d41ed0b2bb5cfc2aaa7b7fdd2d6cb515f6d88adc40ff40e3ec1f560e8a4413'
+# SHA256 sum for the different versions of the ctop redistributable
+ctop_redis_sha256sums:
+  linux:
+    amd64: '43d41ed0b2bb5cfc2aaa7b7fdd2d6cb515f6d88adc40ff40e3ec1f560e8a4413'
+    arm: '6912c057823cb0a5db8bd048d023092bd5bf8ea82403cc86b3021fcd76c742ed'
+    arm64: '16c3f7e0ace1bf9bb8d1170acec1563f1f2d858dbd720c62c01f7cb44ca2139e'
+  darwin:
+    amd64: 'fdcb7e1838d78847ddc29196f819a54ba6716eef8299d43d9cbacd40a08e81af'
+  windows:
+    amd64: 'a0560954705484c07a421d414b140bcd08be8bd71209523c7e0921eb702c8827'
+
+# The OS of the ctop redistributable
+ctop_os: '{{ ansible_system | lower }}'
+# The CPU architecture of the ctop redistributable
+ctop_architecture: '{% if ansible_architecture.startswith("arm") %}{% if ansible_userspace_bits == 64 %}arm64{% else %}arm{% endif %}{% else %}amd64{% endif %}'
+
+# Look up the SHA256 of the ctop redistributable
+ctop_redis_sha256sum: '{{ ctop_redis_sha256sums[ctop_os][ctop_architecture] }}'
 
 # Directory to store files downloaded for ctop
 ctop_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,11 @@
     checksum: 'sha256:{{ ctop_redis_sha256sum }}'
     mode: 'u=rw,go=r'
 
+- name: check if ctop installation directory exists
+  stat:
+    path: '{{ ctop_install_dir }}'
+  register: ctop_dir_check
+
 - name: create the ctop installation dir
   become: yes
   file:
@@ -20,6 +25,7 @@
     group: root
     mode: 'u=rwx,go=rx'
     dest: '{{ ctop_install_dir }}'
+  when: not ctop_dir_check.stat.exists
 
 - name: install ctop
   become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,11 +8,11 @@ ctop_install_path: '{{ ctop_install_dir }}/ctop'
 # Mirror to download the ctop from
 ctop_mirror: 'https://github.com/bcicen/ctop/releases/download/v{{ ctop_version }}'
 
-# The OS of the ctop redistributable
-ctop_os: 'linux'
+# The OS of the ctop redistributable - should be automatically determined
+# ctop_os: 'linux'
 
-# The CPU architecture of the ctop redistributable
-ctop_architecture: 'amd64'
+# The CPU architecture of the ctop redistributable - should be automatically determined
+# ctop_architecture: 'amd64'
 
 # File name of the ctop redistributable file
 ctop_redis_filename: 'ctop-{{ ctop_version }}-{{ ctop_os }}-{{ ctop_architecture }}'


### PR DESCRIPTION
This adds support for the role to work on arm linux, arm64 linux, and
amd64 darwin. It attempts to determine the appropraite architecture and
operating system choice and download the appropriate binary and check
the SHA256 of that downloaded binary.

In addition, a small change had to be made to the creation of the ctop
installation directory for operating systems where `/usr/local/bin` may
not be owned by root, like MacOS with homebrew.

DCO-1.1-Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>